### PR TITLE
feat: use rgrep and tree view auto sizing

### DIFF
--- a/dot_config/nvim/lua/plugins/nvim-telescope.lua
+++ b/dot_config/nvim/lua/plugins/nvim-telescope.lua
@@ -1,5 +1,6 @@
 local builtin = require('telescope.builtin')
 
 vim.keymap.set('n', '<leader>ff', builtin.find_files, {})
+vim.keymap.set('n', '<leader>fg', builtin.live_grep, {})
 vim.api.nvim_set_hl(0, 'TelescopeNormal', {bg='#181818'})
 vim.api.nvim_set_hl(0, 'TelescopeSelection', {bg='#424242'})

--- a/dot_config/nvim/lua/plugins/nvim-tree.lua
+++ b/dot_config/nvim/lua/plugins/nvim-tree.lua
@@ -2,7 +2,11 @@ vim.g.loaded_netrw = 1
 vim.g.loaded_netrwPlugin = 1
 vim.opt.termguicolors = true
 
-require("nvim-tree").setup()
+require("nvim-tree").setup({
+	view = {
+		adaptive_size = true
+	}
+})
 vim.keymap.set('n', '<leader>e', ':NvimTreeToggle<CR>', {noremap = true})
 
 local function open_nvim_tree(data)


### PR DESCRIPTION
* nvim-telescope can now look for content inside files with a tool like rgrep (must be installed already).

* nvim-tree now resizes the tree window automatically to fit all the content.